### PR TITLE
feat(llm): add Azure OpenAI integration

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -22,6 +22,7 @@ venv/bin/python ./tools/llm_api.py --prompt "What is the capital of France?" --p
 
 The LLM API supports multiple providers:
 - OpenAI (default, model: gpt-4o)
+- Azure OpenAI (model: configured via AZURE_OPENAI_MODEL_DEPLOYMENT in .env file, defaults to gpt-4o-ms)
 - DeepSeek (model: deepseek-chat)
 - Anthropic (model: claude-3-sonnet-20240229)
 - Gemini (model: gemini-pro)

--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,5 @@ OPENAI_API_KEY=your_openai_api_key_here
 ANTHROPIC_API_KEY=your_anthropic_api_key_here
 DEEPSEEK_API_KEY=your_deepseek_api_key_here
 GOOGLE_API_KEY=your_google_api_key_here
+AZURE_OPENAI_API_KEY=your_azure_openai_api_key_here
+AZURE_OPENAI_MODEL_DEPLOYMENT=gpt-4o-ms


### PR DESCRIPTION
- Add Azure OpenAI as a new LLM provider option
- Configure Azure model deployment via AZURE_OPENAI_MODEL_DEPLOYMENT env var
- Add unit tests for Azure OpenAI client creation and query functionality
- Update environment example with Azure OpenAI credentials
- Update CLI help text to include Azure provider option
- Set default Azure model to 'gpt-4o-ms' with configurable fallback

Technical details:
- Integrate AzureOpenAI client with api version '2024-02-15-preview'
- Add Azure endpoint configuration
- Extend test coverage for Azure-specific scenarios