### PR TITLE
Add OpenAI o1 model support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ html5lib>=1.1
 duckduckgo-search>=4.1.1
 
 # LLM integration
-openai>=1.12.0
+openai>=1.59.8 # o1 support
 anthropic>=0.42.0
 python-dotenv>=1.0.0
 

--- a/tests/test_llm_api.py
+++ b/tests/test_llm_api.py
@@ -281,6 +281,19 @@ class TestLLMAPI(unittest.TestCase):
 
     @unittest.skipIf(skip_llm_tests, skip_message)
     @patch('tools.llm_api.create_llm_client')
+    def test_query_o1_model(self, mock_create_client):
+        mock_create_client.return_value = self.mock_openai_client
+        response = query_llm("Test prompt", model="o1")
+        self.assertEqual(response, "Test OpenAI response")
+        self.mock_openai_client.chat.completions.create.assert_called_once_with(
+            model="o1",
+            messages=[{"role": "user", "content": "Test prompt"}],
+            response_format={"type": "text"},
+            reasoning_effort="low"
+        )
+
+    @unittest.skipIf(skip_llm_tests, skip_message)
+    @patch('tools.llm_api.create_llm_client')
     def test_query_with_existing_client(self, mock_create_client):
         response = query_llm("Test prompt", client=self.mock_openai_client)
         self.assertEqual(response, "Test OpenAI response")

--- a/tools/llm_api.py
+++ b/tools/llm_api.py
@@ -110,13 +110,19 @@ def query_llm(prompt, client=None, model=None, provider="openai"):
                 model = "Qwen/Qwen2.5-32B-Instruct-AWQ"
             
         if provider in ["openai", "local", "deepseek", "azure"]:
-            response = client.chat.completions.create(
-                model=model,
-                messages=[
-                    {"role": "user", "content": prompt}
-                ],
-                temperature=0.7,
-            )
+            kwargs = {
+                "model": model,
+                "messages": [{"role": "user", "content": prompt}],
+                "temperature": 0.7,
+            }
+            
+            # Add o1-specific parameters
+            if model == "o1":
+                kwargs["response_format"] = {"type": "text"}
+                kwargs["reasoning_effort"] = "low"
+                del kwargs["temperature"]
+            
+            response = client.chat.completions.create(**kwargs)
             return response.choices[0].message.content
         elif provider == "anthropic":
             response = client.messages.create(


### PR DESCRIPTION
This PR adds support for OpenAI's o1 model: (1) Add o1 model specific parameters in llm_api.py (response_format and reasoning_effort) (2) Update openai requirement to >=1.59.8 for o1 support (3) Add unit test for o1 model to verify parameters are correctly set. All tests pass and the implementation has been verified with mock tests.