### PR TITLE
[Cursor] Fix Windsurf rules and scratchpad handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,10 +51,13 @@ credentials.json
 **/__pycache__/
 
 # python virtual environment
-/venv/
+.venv/
 
 # pytest
 .pytest_cache/
 
 # vscode
 .vscode/
+
+# Cursor
+.cursorignore

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -4,9 +4,6 @@
     "llm_provider": ["None", "OpenAI", "Anthropic", "DeepSeek", "Google", "Azure OpenAI"],
     "_copy_without_render": [
         "*.py",
-        "*.md",
-        ".cursorrules",
-        ".windsurfrules",
         ".env"
     ]
 } 

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -40,9 +40,27 @@ def setup_env_file():
                         if not key_found:
                             f.write(f'{env_var_name}={llm_api_key}\n')
 
+def handle_ide_rules():
+    """Handle IDE-specific rules files based on project type"""
+    project_type = '{{ cookiecutter.project_type }}'
+    
+    # For Cursor projects: only keep .cursorrules
+    if project_type == 'cursor':
+        if os.path.exists('.windsurfrules'):
+            os.remove('.windsurfrules')
+        if os.path.exists('scratchpad.md'):
+            os.remove('scratchpad.md')
+    # For Windsurf projects: keep both .windsurfrules and scratchpad.md
+    else:
+        if os.path.exists('.cursorrules'):
+            os.remove('.cursorrules')
+
 def main():
     # Set up environment file
     setup_env_file()
+    
+    # Handle IDE-specific rules
+    handle_ide_rules()
     
     # Create virtual environment
     print("\nCreating virtual environment...")

--- a/{{cookiecutter.project_name}}/.windsurfrules
+++ b/{{cookiecutter.project_name}}/.windsurfrules
@@ -1,0 +1,60 @@
+# Instructions
+
+During you interaction with the user, if you find anything reusable in this project (e.g. version of a library, model name), especially about a fix to a mistake you made or a correction you received, you should take note in the `Lessons` section in the `scratchpad.md` file so you will not make the same mistake again. 
+
+You should also use the `scratchpad.md` file as a scratchpad to organize your thoughts. Especially when you receive a new task, you should first review the content of the scratchpad, clear old different task if necessary, first explain the task, and plan the steps you need to take to complete the task. You can use todo markers to indicate the progress, e.g.
+[X] Task 1
+[ ] Task 2
+Also update the progress of the task in the Scratchpad when you finish a subtask.
+Especially when you finished a milestone, it will help to improve your depth of task accomplishment to use the scratchpad to reflect and plan.
+The goal is to help you maintain a big picture as well as the progress of the task. Always refer to the Scratchpad when you plan the next step.
+
+# Tools
+
+Note all the tools are in python. So in the case you need to do batch processing, you can always consult the python files and write your own script.
+
+## LLM
+
+You always have an LLM at your side to help you with the task. For simple tasks, you could invoke the LLM by running the following command:
+```
+venv/bin/python ./tools/llm_api.py --prompt "What is the capital of France?"
+```
+
+But usually it's a better idea to check the content of the file and use the APIs in the `tools/llm_api.py` file to invoke the LLM if needed.
+
+## Web browser
+
+You could use the `tools/web_scraper.py` file to scrape the web.
+```
+venv/bin/python ./tools/web_scraper.py --max-concurrent 3 URL1 URL2 URL3
+```
+This will output the content of the web pages.
+
+## Search engine
+
+You could use the `tools/search_engine.py` file to search the web.
+```
+venv/bin/python ./tools/search_engine.py "your search keywords"
+```
+This will output the search results in the following format:
+```
+URL: https://example.com
+Title: This is the title of the search result
+Snippet: This is a snippet of the search result
+```
+
+## User Specified Lessons
+
+- You have a python venv in ./venv.
+- Include info useful for debugging in the program output.
+- Read the file before you try to edit it.
+- Use LLM to perform flexible text understanding tasks. First test on a few files. After success, make it parallel.
+
+# Lessons
+
+## Windsurf learned
+
+- For search results, ensure proper handling of different character encodings (UTF-8) for international queries
+- Add debug information to stderr while keeping the main output clean in stdout for better pipeline integration
+- When using seaborn styles in matplotlib, use 'seaborn-v0_8' instead of 'seaborn' as the style name due to recent seaborn version changes
+- Use 'gpt-4o' as the model name for OpenAI's GPT-4 with vision capabilities 

--- a/{{cookiecutter.project_name}}/scratchpad.md
+++ b/{{cookiecutter.project_name}}/scratchpad.md
@@ -1,0 +1,31 @@
+# Current Task
+
+[Task description will be added when a new task begins]
+
+## Progress
+- [ ] Task 1
+- [ ] Task 2
+
+## Notes
+- Important discoveries
+- Key decisions
+- Potential issues
+
+## Next Steps
+1. First step
+2. Second step
+
+# Lessons Learned
+
+## Project-Specific Lessons
+- [Lessons learned during the project will be added here]
+
+## General Best Practices
+- For search results, ensure proper handling of different character encodings (UTF-8) for international queries
+- Add debug information to stderr while keeping the main output clean in stdout for better pipeline integration
+- When using seaborn styles in matplotlib, use 'seaborn-v0_8' instead of 'seaborn' as the style name
+- Use appropriate model names for each LLM provider (e.g., gpt-4o for OpenAI with vision)
+
+# Previous Tasks
+
+[Previous tasks will be archived here] 


### PR DESCRIPTION
This PR improves the handling of Windsurf-specific files and configuration:

## Changes
- Updated `.windsurfrules` to be simpler and direct all note-taking to `scratchpad.md`
- Added `scratchpad.md` template for Windsurf projects with sections for:
  - Current task tracking
  - Progress monitoring
  - Notes and discoveries
  - Lessons learned
  - Previous tasks archive
- Updated `post_gen_project.py` to handle IDE-specific files correctly:
  - Cursor projects: only keep `.cursorrules`
  - Windsurf projects: keep both `.windsurfrules` and `scratchpad.md`
- Updated `.gitignore` to use `.venv` instead of `venv` and added `.cursorignore`

## Testing
The template has been tested with both Cursor and Windsurf configurations:
- Cursor projects get only `.cursorrules`
- Windsurf projects get both `.windsurfrules` and `scratchpad.md`
- File contents are appropriate for each IDE's capabilities 