### PR TITLE
[Cursor] fix: use python3 and pip3 commands instead of python and pip

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -94,14 +94,14 @@ def main():
     
     # Create virtual environment
     print("\nCreating virtual environment...")
-    os.system('python -m venv venv')
+    os.system('python3 -m venv venv')
     
     # Install dependencies
     print("\nInstalling dependencies...")
     if platform.system() == 'Windows':
         os.system('venv\\Scripts\\pip install -r requirements.txt')
     else:
-        os.system('venv/bin/pip install -r requirements.txt')
+        os.system('venv/bin/pip3 install -r requirements.txt')
     
     print("\nSetup completed successfully!")
     print("To get started:")

--- a/{{cookiecutter.project_name}}/.cursorrules
+++ b/{{cookiecutter.project_name}}/.cursorrules
@@ -12,7 +12,7 @@ The goal is to help you maintain a big picture as well as the progress of the ta
 
 # Tools
 
-Note all the tools are in python. So in the case you need to do batch processing, you can always consult the python files and write your own script.
+Note all the tools are in python3. So in the case you need to do batch processing, you can always consult the python files and write your own script.
 
 ## Screenshot Verification
 
@@ -20,12 +20,12 @@ The screenshot verification workflow allows you to capture screenshots of web pa
 
 1. Screenshot Capture:
 ```bash
-venv/bin/python tools/screenshot_utils.py URL [--output OUTPUT] [--width WIDTH] [--height HEIGHT]
+venv/bin/python3 tools/screenshot_utils.py URL [--output OUTPUT] [--width WIDTH] [--height HEIGHT]
 ```
 
 2. LLM Verification with Images:
 ```bash
-venv/bin/python tools/llm_api.py --prompt "Your verification question" --provider {openai|anthropic} --image path/to/screenshot.png
+venv/bin/python3 tools/llm_api.py --prompt "Your verification question" --provider {openai|anthropic} --image path/to/screenshot.png
 ```
 
 Example workflow:
@@ -51,7 +51,7 @@ print(response)
 
 You always have an LLM at your side to help you with the task. For simple tasks, you could invoke the LLM by running the following command:
 ```
-venv/bin/python ./tools/llm_api.py --prompt "What is the capital of France?" --provider "anthropic"
+venv/bin/python3 ./tools/llm_api.py --prompt "What is the capital of France?" --provider "anthropic"
 ```
 
 The LLM API supports multiple providers:
@@ -67,16 +67,16 @@ But usually it's a better idea to check the content of the file and use the APIs
 ## Web browser
 
 You could use the `tools/web_scraper.py` file to scrape the web.
-```
-venv/bin/python ./tools/web_scraper.py --max-concurrent 3 URL1 URL2 URL3
+```bash
+venv/bin/python3 ./tools/web_scraper.py --max-concurrent 3 URL1 URL2 URL3
 ```
 This will output the content of the web pages.
 
 ## Search engine
 
 You could use the `tools/search_engine.py` file to search the web.
-```
-venv/bin/python ./tools/search_engine.py "your search keywords"
+```bash
+venv/bin/python3 ./tools/search_engine.py "your search keywords"
 ```
 This will output the search results in the following format:
 ```
@@ -90,7 +90,7 @@ If needed, you can further use the `web_scraper.py` file to scrape the web page 
 
 ## User Specified Lessons
 
-- You have a python venv in ./venv. Use it.
+- You have a python3 venv in ./venv. Use it.
 - Include info useful for debugging in the program output.
 - Read the file before you try to edit it.
 - Due to Cursor's limit, when you use `git` and `gh` and need to submit a multiline commit message, first write the message in a file, and then use `git commit -F <filename>` or similar command to commit. And then remove the file. Include "[Cursor] " in the commit message and PR title.

--- a/{{cookiecutter.project_name}}/.windsurfrules
+++ b/{{cookiecutter.project_name}}/.windsurfrules
@@ -11,7 +11,7 @@ The goal is to help you maintain a big picture as well as the progress of the ta
 
 # Tools
 
-Note all the tools are in python. So in the case you need to do batch processing, you can always consult the python files and write your own script.
+Note all the tools are in python3. So in the case you need to do batch processing, you can always consult the python files and write your own script.
 
 ## Screenshot Verification
 
@@ -19,12 +19,12 @@ The screenshot verification workflow allows you to capture screenshots of web pa
 
 1. Screenshot Capture:
 ```bash
-venv/bin/python tools/screenshot_utils.py URL [--output OUTPUT] [--width WIDTH] [--height HEIGHT]
+venv/bin/python3 tools/screenshot_utils.py URL [--output OUTPUT] [--width WIDTH] [--height HEIGHT]
 ```
 
 2. LLM Verification with Images:
 ```bash
-venv/bin/python tools/llm_api.py --prompt "Your verification question" --provider {openai|anthropic} --image path/to/screenshot.png
+venv/bin/python3 tools/llm_api.py --prompt "Your verification question" --provider {openai|anthropic} --image path/to/screenshot.png
 ```
 
 Example workflow:
@@ -50,7 +50,7 @@ print(response)
 
 You always have an LLM at your side to help you with the task. For simple tasks, you could invoke the LLM by running the following command:
 ```
-venv/bin/python ./tools/llm_api.py --prompt "What is the capital of France?"
+venv/bin/python3 ./tools/llm_api.py --prompt "What is the capital of France?"
 ```
 
 But usually it's a better idea to check the content of the file and use the APIs in the `tools/llm_api.py` file to invoke the LLM if needed.
@@ -59,7 +59,7 @@ But usually it's a better idea to check the content of the file and use the APIs
 
 You could use the `tools/web_scraper.py` file to scrape the web.
 ```
-venv/bin/python ./tools/web_scraper.py --max-concurrent 3 URL1 URL2 URL3
+venv/bin/python3 ./tools/web_scraper.py --max-concurrent 3 URL1 URL2 URL3
 ```
 This will output the content of the web pages.
 
@@ -67,7 +67,7 @@ This will output the content of the web pages.
 
 You could use the `tools/search_engine.py` file to search the web.
 ```
-venv/bin/python ./tools/search_engine.py "your search keywords"
+venv/bin/python3 ./tools/search_engine.py "your search keywords"
 ```
 This will output the search results in the following format:
 ```
@@ -80,7 +80,7 @@ Snippet: This is a snippet of the search result
 
 ## User Specified Lessons
 
-- You have a python venv in ./venv.
+- You have a python3 venv in ./venv.
 - Include info useful for debugging in the program output.
 - Read the file before you try to edit it.
 - Use LLM to perform flexible text understanding tasks. First test on a few files. After success, make it parallel.


### PR DESCRIPTION
This PR fixes the issue where the post-generation script fails on systems that only have python3 and pip3 installed (like macOS).

## Changes
1. Use python3 instead of python for creating virtual environment in post_gen_project.py
2. Use pip3 instead of pip for installing dependencies in post_gen_project.py
3. Update all python commands in template files (.cursorrules and .windsurfrules) to use python3

## Testing
The changes have been tested on macOS where only python3 and pip3 are available. The cookiecutter template now works correctly in this environment. 