### PR TITLE
Improve LLM provider prompt to make it clearer that it's optional

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -2,11 +2,11 @@
     "__help": {
         "project_name": "Name of your project (must start with a letter, contain only lowercase letters, numbers, and hyphens)",
         "project_type": "Choose your IDE: Cursor (recommended) or Windsurf",
-        "llm_provider": "The following section is completely OPTIONAL. If you have an API key from any of these providers, you can enable advanced AI features like multi-modal analysis and screenshot verification. If not, just select 'None' - the project works perfectly fine without these features."
+        "llm_provider": "[Optional] Select your LLM provider. If you have an API key from any of these providers, you can enable advanced AI features like multi-modal analysis and screenshot verification."
     },
     "project_name": "my-project",
     "project_type": ["cursor", "windsurf"],
-    "llm_provider": ["None", "OpenAI", "Anthropic", "DeepSeek", "Google", "Azure OpenAI"],
+    "llm_provider [Optional. Press Enter to use None]": ["None", "OpenAI", "Anthropic", "DeepSeek", "Google", "Azure OpenAI"],
     "_copy_without_render": [
         "*.py",
         ".env"

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -4,7 +4,7 @@ import platform
 
 def setup_env_file():
     """Set up the .env file with API key if provided"""
-    llm_provider = '{{ cookiecutter.llm_provider }}'
+    llm_provider = '{{ cookiecutter["llm_provider [Optional. Press Enter to use None]"] }}'
     
     # If provider != 'None', retrieve whatever was saved in pre_gen_project.py
     if llm_provider != 'None':
@@ -43,7 +43,7 @@ def setup_env_file():
 def handle_ide_rules():
     """Handle IDE-specific rules files based on project type"""
     project_type = '{{ cookiecutter.project_type }}'
-    llm_provider = '{{ cookiecutter.llm_provider }}'
+    llm_provider = '{{ cookiecutter["llm_provider [Optional. Press Enter to use None]"] }}'
     
     # For Cursor projects: only keep .cursorrules
     if project_type == 'cursor':

--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -4,7 +4,7 @@ import sys
 # Get user input variables
 project_name = '{{ cookiecutter.project_name }}'
 project_type = '{{ cookiecutter.project_type }}'
-llm_provider = '{{ cookiecutter.llm_provider }}'
+llm_provider = '{{ cookiecutter["llm_provider [Optional. Press Enter to use None]"] }}'
 valid_providers = ['None', 'OpenAI', 'Anthropic', 'DeepSeek', 'Google', 'Azure OpenAI']
 
 # Validate project name


### PR DESCRIPTION
Improve LLM provider prompt to make it clearer that it's optional

This PR improves the user experience by making it more obvious that the LLM provider selection is optional. The prompt now includes "[Optional. Press Enter to use None]" in the selection menu itself.

Changes:
- Modified the variable name in `cookiecutter.json` to include the optional message
- Updated the variable references in hook scripts to match the new name

Fixes #58 