### PR TITLE
[Cursor] Fix unit test imports and dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -31,6 +31,6 @@ seaborn>=0.13.1
 tabulate
 
 # Utilities
-aiohttp==3.9.3
+aiohttp==3.11.12
 requests>=2.28.0
 uuid

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,0 +1,3 @@
+"""
+Tools package for various utilities including LLM API integration, web scraping, and token tracking.
+""" 

--- a/tools/llm_api.py
+++ b/tools/llm_api.py
@@ -12,8 +12,8 @@ import base64
 from typing import Optional, Union, List
 import mimetypes
 import time
-import token_tracker
-from token_tracker import TokenUsage, APIResponse, get_token_tracker
+from . import token_tracker
+from .token_tracker import TokenUsage, APIResponse, get_token_tracker
 
 def load_environment():
     """Load environment variables from .env files in order of precedence"""


### PR DESCRIPTION
[Cursor] Fix unit test imports and dependencies

- Fixed token_tracker import in llm_api.py to use relative imports
- Added __init__.py to make tools a proper Python package
- Updated aiohttp version in requirements.txt to match installed version

All unit tests are now passing (44 passed, 2 skipped) 