### PR TITLE
[Cursor] Update README.md with Python version compatibility note

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Devin impressed many by acting like an intern who writes its own plan, updates t
    cookiecutter gh:grapeot/devin.cursorrules --checkout template
    ```
 
+   Note we had reports on python 3.13 isn't compatible (Issue [#76](https://github.com/grapeot/devin.cursorrules/issues/76)). It's recommended to use 3.12 or lower for now.
+
    **Option 2: Manual Setup**
    Copy the `tools` folder and the following config files into your project root folder: Windsurf users need both `.windsurfrules` and `scratchpad.md` files. Cursor users only need the `.cursorrules` file. Github Copilot users need the `.github/copilot-instructions.md` file.
 


### PR DESCRIPTION
[Cursor] Update README.md with Python version compatibility note

This PR adds a note about Python version compatibility in the README.md file, specifically mentioning that Python 3.13 is not compatible (Issue #76) and recommending Python 3.12 or lower.

Fixes #76
Fixes #81
