### PR TITLE
Refactor plan_exec_llm to use centralized LLM query function

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -127,6 +127,7 @@ If needed, you can further use the `web_scraper.py` file to scrape the web page 
 - When using seaborn styles in matplotlib, use 'seaborn-v0_8' instead of 'seaborn' as the style name due to recent seaborn version changes
 - Use `gpt-4o` as the model name for OpenAI. It is the latest GPT model and has vision capabilities as well. `o1` is the most advanced and expensive model from OpenAI. Use it when you need to do reasoning, planning, or get blocked.
 - Use `claude-3-5-sonnet-20241022` as the model name for Claude. It is the latest Claude model and has vision capabilities as well.
+- When running Python scripts that import from other local modules, use `PYTHONPATH=.` to ensure Python can find the modules. For example: `PYTHONPATH=. python tools/plan_exec_llm.py` instead of just `python tools/plan_exec_llm.py`. This is especially important when using relative imports.
 
 # Multi-Agent Scratchpad
 

--- a/tools/llm_api.py
+++ b/tools/llm_api.py
@@ -187,7 +187,7 @@ def query_llm(prompt: str, client=None, model=None, provider="openai", image_pat
                 prompt_tokens=response.usage.prompt_tokens,
                 completion_tokens=response.usage.completion_tokens,
                 total_tokens=response.usage.total_tokens,
-                reasoning_tokens=response.usage.completion_tokens_details.reasoning_tokens if hasattr(response.usage, 'completion_tokens_details') else None
+                reasoning_tokens=None  # Only o1 model provides reasoning tokens
             )
             
             # Calculate cost


### PR DESCRIPTION
- Update plan_exec_llm to use query_llm from llm_api
- Remove redundant LLM client creation and token tracking logic in plan_exec_llm
- Add support for multiple LLM providers and models via CLI arguments
- Simplify token usage tracking by leveraging existing infrastructure
- Remove hardcoded OpenAI-specific code to improve provider flexibility
- edited cursor rule to deal with virtual environment