### PR TITLE
[Cursor] Enhance LLM model versions and add current year rule for bet…

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -101,5 +101,6 @@ If needed, you can further use the `web_scraper.py` file to scrape the web page 
 - Add debug information to stderr while keeping the main output clean in stdout for better pipeline integration
 - When using seaborn styles in matplotlib, use 'seaborn-v0_8' instead of 'seaborn' as the style name due to recent seaborn version changes
 - Use 'gpt-4o' as the model name for OpenAI's GPT-4 with vision capabilities
+- When searching for recent news, use the current year (2025) instead of previous years, or simply use the "recent" keyword to get the latest information
 
 # Scratchpad

--- a/tools/llm_api.py
+++ b/tools/llm_api.py
@@ -148,9 +148,9 @@ def query_llm(prompt: str, client=None, model=None, provider="openai", image_pat
             elif provider == "siliconflow":
                 model = "deepseek-ai/DeepSeek-R1"
             elif provider == "anthropic":
-                model = "claude-3-sonnet-20240229"
+                model = "claude-3-7-sonnet-20250219"
             elif provider == "gemini":
-                model = "gemini-pro"
+                model = "gemini-2.0-flash-exp"
             elif provider == "local":
                 model = "Qwen/Qwen2.5-32B-Instruct-AWQ"
         
@@ -255,7 +255,7 @@ def main():
         elif args.provider == "siliconflow":
             args.model = "deepseek-ai/DeepSeek-R1"
         elif args.provider == 'anthropic':
-            args.model = "claude-3-5-sonnet-20241022"
+            args.model = "claude-3-7-sonnet-20250219"
         elif args.provider == 'gemini':
             args.model = "gemini-2.0-flash-exp"
         elif args.provider == 'azure':


### PR DESCRIPTION
…ter performance and capabilities

Updated LLM model versions, upgrading Anthropic to claude-3-7-sonnet-20250219 and Gemini to gemini-2.0-flash-exp.
Added rule to use the current year (2025) for recent news searches, preventing the model from defaulting to its training data cutoff year.

更新 LLM 模型版本，將 Anthropic 模型升級至 claude-3-7-sonnet-20250219，並將 Gemini 模型升級至 gemini-2.0-flash-exp。 
新增使用當前年份（2025）進行近期新聞搜索的規則，避免模型預設按訓練資料截止年份查詢。

LLM モデルバージョンを更新し、Anthropic モデルを claude-3-7-sonnet-20250219 に、Gemini モデルを gemini-2.0-flash-exp にアップデートして。 
最新ニュース検索に現在の年号（2025）を使用するルールを追加し、モデルがトレーニングデータの締切年をデフォルトとするのを防ぎます。