### PR TITLE
feat: Add user defined openai model provider (#124)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,6 @@
 OPENAI_API_KEY=your_openai_api_key_here
+OPENAI_BASE_URL=https://api.openai.com/v1
+OPENAI_MODEL_DEPLOYMENT=gpt-4o
 ANTHROPIC_API_KEY=your_anthropic_api_key_here
 DEEPSEEK_API_KEY=your_deepseek_api_key_here
 GOOGLE_API_KEY=your_google_api_key_here

--- a/tools/llm_api.py
+++ b/tools/llm_api.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env /workspace/tmp_windsurf/venv/bin/python3
+#!/usr/bin/env python3
 
 import google.generativeai as genai
 from openai import OpenAI, AzureOpenAI
@@ -68,10 +68,12 @@ def encode_image_file(image_path: str) -> tuple[str, str]:
 def create_llm_client(provider="openai"):
     if provider == "openai":
         api_key = os.getenv('OPENAI_API_KEY')
+        base_url = os.getenv('OPENAI_BASE_URL', "https://api.openai.com/v1")
         if not api_key:
             raise ValueError("OPENAI_API_KEY not found in environment variables")
         return OpenAI(
-            api_key=api_key
+            api_key=api_key,
+            base_url=base_url
         )
     elif provider == "azure":
         api_key = os.getenv('AZURE_OPENAI_API_KEY')
@@ -140,7 +142,7 @@ def query_llm(prompt: str, client=None, model=None, provider="openai", image_pat
         # Set default model
         if model is None:
             if provider == "openai":
-                model = "gpt-4o"
+                model = os.getenv('OPENAI_MODEL_DEPLOYMENT', 'gpt-4o')
             elif provider == "azure":
                 model = os.getenv('AZURE_OPENAI_MODEL_DEPLOYMENT', 'gpt-4o-ms')  # Get from env with fallback
             elif provider == "deepseek":

--- a/tools/web_scraper.py
+++ b/tools/web_scraper.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env /workspace/tmp_windsurf/venv/bin/python3
+#!/usr/bin/env python3
 
 import asyncio
 import argparse


### PR DESCRIPTION
Change-Id: Ice3c42381021e474d751528a0b5c4726998a6acb

Hi, 

I am using other OpenAI model providers, with custom base_url and model. So, it should be nice to be configurable and won't hurt others.

And, inside `llm_api.py` and `web_scraper.py`, change to use python3 directly, to be consistent with other tools.